### PR TITLE
Api

### DIFF
--- a/files/Gemfile
+++ b/files/Gemfile
@@ -42,6 +42,8 @@ group :development, :test do
 end
 
 group :development do
+  # Use better_errors to get a full stack trace
+  gem "better_errors"
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/files/Gemfile
+++ b/files/Gemfile
@@ -14,7 +14,7 @@ gem 'coffee-rails', '~> 4.1.0'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.0'
+# gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Unicorn as the app server

--- a/files/Gemfile_api_only
+++ b/files/Gemfile_api_only
@@ -17,7 +17,7 @@ gem 'taperole'
 # Use active_interaction to manage business logic in a service layer
 # gem 'active_interaction'
 # bundle exec rake doc:rails generates the API under doc/api.
-# Use rack-cores to make CORS requests from the browser client
+# Use rack-cors to make CORS requests from the browser client
 # gem 'rack-cors', require: 'rack/cors'
 
 group :development, :test do

--- a/files/Gemfile_api_only
+++ b/files/Gemfile_api_only
@@ -4,23 +4,21 @@ source 'https://rubygems.org'
 gem 'rails', '4.2.5'
 # Use postgresql as the database for Active Record
 gem 'pg'
-# Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
-# Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
-# Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.1.0'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-# Use jquery as the JavaScript library
-gem 'jquery-rails'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.0'
-# bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Unicorn as the app server
 gem 'unicorn'
 # Use Taperole for deployment
 gem 'taperole'
+
+# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+# gem 'jbuilder', '~> 2.0'
+# Use serializers to format json data
+# gem 'active_model_serializers'
+# Use active_interaction to manage business logic in a service layer
+# gem 'active_interaction'
+# bundle exec rake doc:rails generates the API under doc/api.
+# Use rack-cores to make CORS requests from the browser client
+# gem 'rack-cors', require: 'rack/cors'
 
 group :development, :test do
   # Use rspec as the testing framework

--- a/template.rb
+++ b/template.rb
@@ -104,15 +104,18 @@ if yes?("Add SmashingDocs for API documentation? (y/n)")
   end
 end
 
-# Devise
-if yes?("Add Devise or Devise_Auth (if api only app)? (y/n)")
+if api_only
+  # Devise
+  if yes?("Add Devise_Auth? (y/n)")
   devise = true
-  if api_only
     inject_into_file 'Gemfile', after: "gem 'taperole'\n" do <<-RUBY
   gem 'devise_token_auth'
     RUBY
     end
-  else
+  end
+else
+  if yes?("Add Devise? (y/n)")
+    devise = true
     inject_into_file 'Gemfile', after: "gem 'taperole'\n" do <<-RUBY
   gem 'devise'
     RUBY
@@ -159,7 +162,6 @@ generate 'cucumber:install' if cucumber_capybara
 run 'tape installer install'
 # Databases
 run 'rake db:create'
-run 'rake db:migrate'
 
 # -----------------------------
 # GIT

--- a/template.rb
+++ b/template.rb
@@ -8,10 +8,28 @@ def render_file(path)
 end
 
 # -----------------------------
+# API ONLY APP?
+# -----------------------------
+
+if yes?("Is this an API only app with no front-end? (y/n)")
+  api_only = true
+  remove_dir "app/helpers"
+  remove_dir "app/views"
+  remove_dir "app/assets/javascripts"
+  remove_dir "app/assets/stylesheets"
+  gsub_file 'app/controllers/application_controller.rb', /Base/, "API"
+  gsub_file 'app/controllers/application_controller.rb', /protect_from_forgery with: :exception/, ""
+end
+
+# -----------------------------
 # GEMS
 # -----------------------------
 remove_file "Gemfile"
-file 'Gemfile', render_file("#{$path}/files/Gemfile")
+if api_only
+  file 'Gemfile', render_file("#{$path}/files/Gemfile_api_only")
+else
+  file 'Gemfile', render_file("#{$path}/files/Gemfile")
+end
 
 run 'bundle'
 # Rspec
@@ -33,9 +51,10 @@ end
 # Tape
 run 'tape installer install'
 # Turbolinks
-gsub_file 'app/assets/javascripts/application.js', /\/\/= require turbolinks/, ''
-gsub_file 'app/views/layouts/application.html.erb', /, 'data-turbolinks-track' => true/, ""
-
+unless api_only
+  gsub_file 'app/assets/javascripts/application.js', /\/\/= require turbolinks/, ''
+  gsub_file 'app/views/layouts/application.html.erb', /, 'data-turbolinks-track' => true/, ""
+end
 # -----------------------------
 # SETUP
 # -----------------------------
@@ -51,17 +70,6 @@ gsub_file 'README.md', /app_name/, app_name.upcase
 # -----------------------------
 # GEM ADDITIONS (OPTIONAL)
 # -----------------------------
-
-# API only app
-if yes?("Is this an API only app with no front-end or admin interface? (y/n)")
-  api_only = true
-  remove_dir "app/helpers"
-  remove_dir "app/views"
-  remove_dir "app/assets/javascripts"
-  remove_dir "app/assets/stylesheets"
-  gsub_file 'app/controllers/application_controller.rb', /Base/, "API"
-  gsub_file 'app/controllers/application_controller.rb', /:exception/, ":null_session"
-end
 
 # SmashingDocs
 if yes?("Add SmashingDocs for API documentation? (y/n)")
@@ -83,32 +91,30 @@ gem 'devise'
 end
 
 # ActiveAdmin
-unless api_only
-  if yes?("Add ActiveAdmin? (y/n)")
-    active_admin = true
-    gsub_file 'Gemfile', /^gem\s+["']devise["'].*$/,''
-    inject_into_file 'Gemfile', after: "gem 'taperole'\n" do <<-RUBY
-  # Use activeadmin for admin interface
-  gem 'activeadmin', '~> 1.0.0.pre2'
-  gem 'devise'
-    RUBY
-    end
-  end
-
-# Cucumber and Capybara
-  if yes?("Add Cucumber and Capybara? (y/n)")
-    cucumber_capybara = true
-    inject_into_file 'Gemfile', after: "group :development, :test do\n" do <<-RUBY
-    # Use cucumber-rails for automated feature tests
-    gem 'cucumber-rails', :require => false
-    # Use capybara-rails to simulate how a user interacts with the app
-    gem 'capybara'
-    RUBY
-    end
+if yes?("Add ActiveAdmin? (y/n)")
+  active_admin = true
+  gsub_file 'Gemfile', /^gem\s+["']devise["'].*$/,''
+  inject_into_file 'Gemfile', after: "gem 'taperole'\n" do <<-RUBY
+# Use activeadmin for admin interface
+gem 'activeadmin', '~> 1.0.0.pre2'
+gem 'devise'
+  RUBY
   end
 end
 
-run 'bundle' if smashing_docs || devise || active_admin || cucumber_capybara
+# Cucumber and Capybara
+if yes?("Add Cucumber and Capybara? (y/n)")
+  cucumber_capybara = true
+  inject_into_file 'Gemfile', after: "group :development, :test do\n" do <<-RUBY
+  # Use cucumber-rails for automated feature tests
+  gem 'cucumber-rails', :require => false
+  # Use capybara-rails to simulate how a user interacts with the app
+  gem 'capybara'
+  RUBY
+  end
+end
+
+run 'bundle' if smashing_docs || devise || active_admin || cucumber_capybara || api_only
 generate 'docs:install' if smashing_docs
 generate 'devise:install' if devise
 generate 'active_admin:install' if active_admin

--- a/template.rb
+++ b/template.rb
@@ -47,8 +47,6 @@ CodeClimate::TestReporter.start
   RUBY
   end
 end
-# Tape
-run 'tape installer install'
 # Turbolinks
 unless api_only
   gsub_file 'app/assets/javascripts/application.js', /\/\/= require turbolinks/, ''
@@ -155,8 +153,11 @@ generate 'active_admin:install' if active_admin
 generate 'cucumber:install' if cucumber_capybara
 
 # -----------------------------
-# DATABASES
+# DEPLOYMENT
 # -----------------------------
+# Tape
+run 'tape installer install'
+# Databases
 run 'rake db:create'
 run 'rake db:migrate'
 


### PR DESCRIPTION
## Why?
- To allow dev to set up a Rails template for an API only app
## What Changed?

If API only: 
- Remove helpers, views, javascripts, stylesheets
- Edit application_controller
- Create alternate Gemfile with api-only gems and without style gems
- If yes to devise, devise_auth_token instead of devise gem
- If yes to api_only, do not ask for ActiveAdmin or Cucumber/Capybara
