### PR TITLE
Create option for api with admin

### DIFF
--- a/files/database_cleaner.rb
+++ b/files/database_cleaner.rb
@@ -17,4 +17,5 @@ RSpec.configure do |config|
 
   config.after(:each) do
     DatabaseCleaner.clean
+  end
 end

--- a/files/shoulda_matchers.rb
+++ b/files/shoulda_matchers.rb
@@ -1,6 +1,6 @@
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec
- 	  with.library :rails
+    with.library :rails
   end
 end

--- a/template.rb
+++ b/template.rb
@@ -47,8 +47,8 @@ end
 
 def add_gem_configs
   bundle
-  read_configs
   rspec_config
+  read_configs
   factory_girl_config
   database_cleaner_config
   shoulda_matchers_config

--- a/template.rb
+++ b/template.rb
@@ -6,17 +6,22 @@ end
 
 def api_only_install
   api_only_modifications
-  api_gemfile
+  devise_auth?
 end
 
 def api_with_admin_install
-  api_gemfile
   remove_turbolinks
+  devise_auth?
+  active_admin?
+  cucumber_capybara?
 end
 
 def integrated_app_install
   integrated_app_gemfile
   remove_turbolinks
+  devise?
+  active_admin?
+  cucumber_capybara?
 end
 
 def api_only_modifications
@@ -65,12 +70,7 @@ def rspec_config
 end
 
 def read_configs
-  inside 'spec' do
-    inject_into_file 'rails_helper.rb', after: "require 'rspec/rails'\n" do <<-RUBY
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
-    RUBY
-    end
-  end
+  gsub_file 'spec/rails_helper.rb', /# Dir/, "Dir"
 end
 
 def factory_girl_config
@@ -202,19 +202,15 @@ remove_file "Gemfile"
 # -----------------------------
 # API ONLY APP?
 # -----------------------------
-if yes?("Is this an API only app with no front-end or admin interface? (y/n)")
-  api_only_install
-  devise_auth?
-elsif yes?("Is this an API app with an admin interface?")
-  api_with_admin_install
-  devise_auth?
-  active_admin?
-  cucumber_capybara?
+if yes?("Is this an API app? (y/n)")
+  api_gemfile
+  if yes?("Does this API app have an admin interface?")
+    api_with_admin_install
+  else
+    api_only_install
+  end
 else
   integrated_app_install
-  devise?
-  active_admin?
-  cucumber_capybara?
 end
 smashing_docs?
 # -----------------------------

--- a/template.rb
+++ b/template.rb
@@ -6,25 +6,43 @@ end
 
 def api_only_install
   api_only_modifications
-  api_only_gemfile
+  api_gemfile
+  devise_auth?
+  smashing_docs?
 end
 
-def api_only_modifications
-  remove_dir "app/helpers"
-  remove_dir "app/views"
-  remove_dir "app/assets/javascripts"
-  remove_dir "app/assets/stylesheets"
-  gsub_file "app/controllers/application_controller.rb", /Base/, "API"
-  gsub_file "app/controllers/application_controller.rb", /protect/, "# protect"
-end
-
-def api_only_gemfile
-  file "Gemfile", render_file("#{$path}/files/Gemfile_api_only")
+def api_with_admin_install
+  api_gemfile
+  remove_turbolinks
+  devise_auth?
+  active_admin?
+  cucumber_capybara?
+  smashing_docs?
 end
 
 def integrated_app_install
   integrated_app_gemfile
   remove_turbolinks
+  devise?
+  active_admin?
+  cucumber_capybara?
+end
+
+def api_only_modifications
+  api_remove_files
+  gsub_file "app/controllers/application_controller.rb", /Base/, "API"
+  gsub_file "app/controllers/application_controller.rb", /protect/, "# protect"
+end
+
+def api_remove_files
+  remove_dir "app/helpers"
+  remove_dir "app/views"
+  remove_dir "app/assets/javascripts"
+  remove_dir "app/assets/stylesheets"
+end
+
+def api_gemfile
+  file "Gemfile", render_file("#{$path}/files/Gemfile_api_only")
 end
 
 def integrated_app_gemfile
@@ -123,7 +141,6 @@ def smashing_docs?
 end
 
 def devise_auth?
-  # Devise
   if yes?("Add Devise_Auth? (y/n)")
     @devise_auth = true
     inject_into_file 'Gemfile', after: "gem 'taperole'\n" do <<-RUBY
@@ -144,7 +161,6 @@ gem 'devise'
 end
 
 def active_admin?
-  # ActiveAdmin
   if yes?("Add ActiveAdmin? (y/n)")
     @active_admin = true
     gsub_file 'Gemfile', /gem 'devise'/, ""
@@ -158,7 +174,6 @@ gem 'devise'
 end
 
 def cucumber_capybara?
-  # Cucumber and Capybara
   if yes?("Add Cucumber and Capybara? (y/n)")
     @cucumber_capybara = true
     inject_into_file 'Gemfile', after: "group :development, :test do\n" do <<-RUBY
@@ -188,14 +203,11 @@ remove_file "Gemfile"
 # -----------------------------
 if yes?("Is this an API only app with no front-end or admin interface? (y/n)")
   api_only_install
-  devise_auth?
+elsif yes?("Is this an API app with an admin interface?")
+  api_with_admin_install
 else
   integrated_app_install
-  devise?
-  active_admin?
-  cucumber_capybara?
 end
-smashing_docs?
 
 # -----------------------------
 # DATABASE


### PR DESCRIPTION
## Why?
- For apps that are api but with an admin interface
## What Changed?
- Created option for api with admin interface
- If this option is chosen, do not delete front end files or edit application controller
- Otherwise, the same as api_only install
