### PR TITLE
Add .DS_Store to git ignore.

### DIFF
--- a/lib/file_modifier.rb
+++ b/lib/file_modifier.rb
@@ -20,6 +20,10 @@ def git_ignore_append
 config/initializers/secret_token.rb
 config/secrets.yml
 config/database.yml
+
+# Ignore .DS_Store files
+.DS_Store
+*/.DS_Store
     EOF
   end
 end


### PR DESCRIPTION
## Why?
- Missing best practice of adding DS_Store to git ignore
