### PR TITLE
Change name to Boxcar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ rvm:
 before_script:
   - gem install rails --no-ri --no-rdoc
   - cd ..
-  - smashing-template/bin/gen_interactive_app
-  - smashing-template/bin/gen_api_only_app
-  - smashing-template/bin/gen_api_admin_app
+  - boxcar/bin/gen_interactive_app
+  - boxcar/bin/gen_api_only_app
+  - boxcar/bin/gen_api_admin_app
 script:
-  - rubocop ./smashing-template
+  - rubocop ./boxcar
   - cd interactive_app
   - bundle exec rubocop
   - bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://travis-ci.org/smashingboxes/smashing-template.svg?branch=master)](https://travis-ci.org/smashingboxes/smashing-template)
+[![Build Status](https://travis-ci.org/smashingboxes/boxcar.svg?branch=master)](https://travis-ci.org/smashingboxes/boxcar)
 
-# Smashing-Template
+# Boxcar
 
-Smashing-Template is the Rails application template used at
+Boxcar is the Rails application template used at
 [Smashing Boxes](https://smashingboxes.com/) according to our best practices.
 
 ## Requirements
@@ -17,8 +17,8 @@ and that the application will be deployed using:
 ## Installation
 To create a new Rails app with this template, do the following:
 ```
-git clone https://github.com/smashingboxes/smashing-template.git
-rails new [app_name] -m smashing-template/template.rb -B
+git clone https://github.com/smashingboxes/boxcar.git
+rails new [app_name] -m boxcar/template.rb -B
 ```
 Note that the ``-B`` is optional and equivalent to ``--skip-bundle``. Since there is a bundle install command inside the template, the final bundle when creating a new Rails app is unnecessary.
 
@@ -85,7 +85,7 @@ Once these app-type dependent modifications are complete, the template will modi
 
 ## Gemfile
 
-Smashing Template contains application gems including:
+Boxcar contains application gems including:
 
 * [Devise](https://github.com/plataformatec/devise) for authentication
 * [Devise Token Auth](https://github.com/lynndylanhurley/devise_token_auth) for token-based authentication
@@ -113,4 +113,3 @@ And testing gems including:
 * [Rubocop](https://github.com/bbatsov/rubocop) for linting
 * [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) for common RSpec matchers
 * [Smashing Docs](https://github.com/thoughtbot/shoulda-matchers) for API documentation
-

--- a/bin/gen_api_admin_app
+++ b/bin/gen_api_admin_app
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 rm -rf api_admin_app
-printf 'y\ny\ny\ny\ny\nn' | rails new api_admin_app -m smashing-template/template.rb -B
+printf 'y\ny\ny\ny\ny\nn' | rails new api_admin_app -m boxcar/template.rb -B
 ( cd api_admin_app ; cp config/database.example.yml config/database.yml )
 ( cd api_admin_app ; cp config/secrets.example.yml config/secrets.yml )
 ( cd api_admin_app ; bundle exec rake db:migrate --trace )
 ( cd api_admin_app ; bundle exec rake db:test:prepare --trace )
-( cd api_admin_app ; cp ../smashing-template/test/example_spec.rb spec/example_spec.rb )
-( cd api_admin_app ; cp ../smashing-template/test/example.feature features/example.feature )
-( cd api_admin_app ; cp ../smashing-template/test/example_steps.rb features/example_steps.rb )
+( cd api_admin_app ; cp ../boxcar/test/example_spec.rb spec/example_spec.rb )
+( cd api_admin_app ; cp ../boxcar/test/example.feature features/example.feature )
+( cd api_admin_app ; cp ../boxcar/test/example_steps.rb features/example_steps.rb )

--- a/bin/gen_api_only_app
+++ b/bin/gen_api_only_app
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 rm -rf api_only_app
-printf 'y\nn\ny\ny\nn' | rails new api_only_app -m smashing-template/template.rb -B
+printf 'y\nn\ny\ny\nn' | rails new api_only_app -m boxcar/template.rb -B
 ( cd api_only_app ; cp config/database.example.yml config/database.yml )
 ( cd api_only_app ; cp config/secrets.example.yml config/secrets.yml )
 ( cd api_only_app ; bundle exec rake db:migrate --trace )
 ( cd api_only_app ; bundle exec rake db:test:prepare --trace )
-( cd api_only_app ; cp ../smashing-template/test/example_spec.rb spec/example_spec.rb )
+( cd api_only_app ; cp ../boxcar/test/example_spec.rb spec/example_spec.rb )

--- a/bin/gen_interactive_app
+++ b/bin/gen_interactive_app
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 rm -rf interactive_app
-printf 'n\ny\ny\nn' | rails new interactive_app -m ./smashing-template/template.rb -B
+printf 'n\ny\ny\nn' | rails new interactive_app -m ./boxcar/template.rb -B
 ( cd interactive_app ; cp config/database.example.yml config/database.yml )
 ( cd interactive_app ; cp config/secrets.example.yml config/secrets.yml )
 ( cd interactive_app ; bundle exec rake db:migrate --trace )
 ( cd interactive_app ; bundle exec rake db:test:prepare --trace )
-( cd interactive_app ; cp ../smashing-template/test/example_spec.rb spec/example_spec.rb )
-( cd interactive_app ; cp ../smashing-template/test/example.feature features/example.feature )
-( cd interactive_app ; cp ../smashing-template/test/example_steps.rb features/example_steps.rb )
+( cd interactive_app ; cp ../boxcar/test/example_spec.rb spec/example_spec.rb )
+( cd interactive_app ; cp ../boxcar/test/example.feature features/example.feature )
+( cd interactive_app ; cp ../boxcar/test/example_steps.rb features/example_steps.rb )

--- a/lib/file_modifier.rb
+++ b/lib/file_modifier.rb
@@ -8,7 +8,6 @@ end
 
 def generate_readme
   remove_file 'README.rdoc'
-  file 'README.md', render_file(path("README.md"))
   gsub_file 'README.md', /app_name/, app_name.upcase
 end
 
@@ -47,6 +46,8 @@ end
 def rubocop_clean_up
   remove_file 'config/initializers/backtrace_silencers.rb'
   gsub_file 'config/environments/production.rb', /^\s*#.*\n/, ''
+  gsub_file 'config/environments/production.rb', /\[\s/, '['
+  gsub_file 'config/environments/production.rb', /\s\]/, ']'
   gsub_file 'db/seeds.rb', /^\s*#.*\n/, ''
   if @cucumber_capybara
     remove_file 'lib/tasks/cucumber.rake'

--- a/lib/gem_configurator.rb
+++ b/lib/gem_configurator.rb
@@ -16,7 +16,32 @@ def bundle
   run 'bundle'
 end
 
+def clean_up_auto_files
+  gsub_file 'config/environments/development.rb',
+            /config.action_mailer.perform_caching/,
+            '# config.action_mailer.perform_caching'
+  gsub_file 'config/environments/development.rb',
+            /config.file_watcher/,
+            '# config.file_watcher'
+  gsub_file 'config/environments/test.rb',
+            /config.action_mailer.perform_caching/,
+            '# config.action_mailer.perform_caching'
+  gsub_file 'config/environments/test.rb',
+            /config.public_file_server.enabled/,
+            '# config.public_file_server.enabled'
+  gsub_file 'config/environments/test.rb', /config.public_file_server.headers/, ''
+  gsub_file 'config/environments/test.rb', /'Cache-Control'/, ""
+  gsub_file 'config/environments/test.rb', /}/, ""
+  gsub_file 'config/initializers/new_framework_defaults.rb',
+            /ActiveSupport.to_time_preserves_timezone/,
+            '# ActiveSupport.to_time_preserves_timezone'
+  gsub_file 'config/initializers/new_framework_defaults.rb',
+            /ActiveSupport.halt_callback_chains_on_return_false/,
+            '# ActiveSupport.halt_callback_chains_on_return_false'
+end
+
 def rspec_config
+  clean_up_auto_files
   generate 'rspec:install'
 end
 

--- a/template.rb
+++ b/template.rb
@@ -44,4 +44,4 @@ initialize_git
 # -----------------------------
 # COMPLETE
 # -----------------------------
-puts "\nSmashing-Template successfully created!"
+puts "\nBoxcar Rails Template successfully created!"


### PR DESCRIPTION
## Why?
- Changed name of template to Boxcar
## What Change?
- Changed name throughout
- Comment or sub our problematic auto-generated lines in dev and test environment files
- Modify creation of README.md as this now gets generated with rails new command
