### PR TITLE
Modify name and specify rails version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ rvm:
 before_script:
   - gem install rails --no-ri --no-rdoc
   - cd ..
-  - smashing-template/bin/gen_interactive_app
-  - smashing-template/bin/gen_api_only_app
-  - smashing-template/bin/gen_api_admin_app
+  - boxcar/bin/gen_interactive_app
+  - boxcar/bin/gen_api_only_app
+  - boxcar/bin/gen_api_admin_app
 script:
-  - rubocop ./smashing-template
+  - rubocop ./boxcar
   - cd interactive_app
   - bundle exec rubocop
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.3.0
 before_script:
-  - gem install rails --no-ri --no-rdoc
+  - gem install rails -v 4.2.5 --no-ri --no-rdoc
   - cd ..
   - boxcar/bin/gen_interactive_app
   - boxcar/bin/gen_api_only_app

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://travis-ci.org/smashingboxes/smashing-template.svg?branch=master)](https://travis-ci.org/smashingboxes/smashing-template)
+[![Build Status](https://travis-ci.org/smashingboxes/boxcar.svg?branch=master)](https://travis-ci.org/smashingboxes/boxcar)
 
-# Smashing-Template
+# Boxcar
 
-Smashing-Template is the Rails application template used at
+Boxcar is the Rails application template used at
 [Smashing Boxes](https://smashingboxes.com/) according to our best practices.
 
 ## Requirements
@@ -15,12 +15,14 @@ and that the application will be deployed using:
   - Tape
 
 ## Installation
-To create a new Rails app with this template, do the following:
+To create a new Rails app with this template using Rails 4.2.5, do the following:
 ```
-git clone https://github.com/smashingboxes/smashing-template.git
-rails new [app_name] -m smashing-template/template.rb -B
+git clone https://github.com/smashingboxes/boxcar.git
+rails _4.2.5_ new [app_name] -m boxcar/template.rb -B
 ```
 Note that the ``-B`` is optional and equivalent to ``--skip-bundle``. Since there is a bundle install command inside the template, the final bundle when creating a new Rails app is unnecessary.
+
+Note that this command will be updated when the template is compatible with Rails 5.
 
 ## Options
 When using this template, you will be asked one or more questions to determine what type of Rails app to generate. There are 3 types of apps you can select:
@@ -85,7 +87,7 @@ Once these app-type dependent modifications are complete, the template will modi
 
 ## Gemfile
 
-Smashing Template contains application gems including:
+Boxcar contains application gems including:
 
 * [Devise](https://github.com/plataformatec/devise) for authentication
 * [Devise Token Auth](https://github.com/lynndylanhurley/devise_token_auth) for token-based authentication
@@ -113,4 +115,3 @@ And testing gems including:
 * [Rubocop](https://github.com/bbatsov/rubocop) for linting
 * [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) for common RSpec matchers
 * [Smashing Docs](https://github.com/thoughtbot/shoulda-matchers) for API documentation
-

--- a/bin/gen_api_admin_app
+++ b/bin/gen_api_admin_app
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 rm -rf api_admin_app
-printf 'y\ny\ny\ny\ny\nn' | rails new api_admin_app -m smashing-template/template.rb -B
+printf 'y\ny\ny\ny\ny\nn' | rails _4.2.5_ new api_admin_app -m boxcar/template.rb -B
 ( cd api_admin_app ; cp config/database.example.yml config/database.yml )
 ( cd api_admin_app ; cp config/secrets.example.yml config/secrets.yml )
 ( cd api_admin_app ; bundle exec rake db:migrate --trace )
 ( cd api_admin_app ; bundle exec rake db:test:prepare --trace )
-( cd api_admin_app ; cp ../smashing-template/test/example_spec.rb spec/example_spec.rb )
-( cd api_admin_app ; cp ../smashing-template/test/example.feature features/example.feature )
-( cd api_admin_app ; cp ../smashing-template/test/example_steps.rb features/example_steps.rb )
+( cd api_admin_app ; cp ../boxcar/test/example_spec.rb spec/example_spec.rb )
+( cd api_admin_app ; cp ../boxcar/test/example.feature features/example.feature )
+( cd api_admin_app ; cp ../boxcar/test/example_steps.rb features/example_steps.rb )

--- a/bin/gen_api_only_app
+++ b/bin/gen_api_only_app
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 rm -rf api_only_app
-printf 'y\nn\ny\ny\nn' | rails new api_only_app -m smashing-template/template.rb -B
+printf 'y\nn\ny\ny\nn' | rails _4.2.5_ new api_only_app -m boxcar/template.rb -B
 ( cd api_only_app ; cp config/database.example.yml config/database.yml )
 ( cd api_only_app ; cp config/secrets.example.yml config/secrets.yml )
 ( cd api_only_app ; bundle exec rake db:migrate --trace )
 ( cd api_only_app ; bundle exec rake db:test:prepare --trace )
-( cd api_only_app ; cp ../smashing-template/test/example_spec.rb spec/example_spec.rb )
+( cd api_only_app ; cp ../boxcar/test/example_spec.rb spec/example_spec.rb )

--- a/bin/gen_interactive_app
+++ b/bin/gen_interactive_app
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 rm -rf interactive_app
-printf 'n\ny\ny\nn' | rails new interactive_app -m ./smashing-template/template.rb -B
+printf 'n\ny\ny\nn' | rails _4.2.5_ new interactive_app -m ./boxcar/template.rb -B
 ( cd interactive_app ; cp config/database.example.yml config/database.yml )
 ( cd interactive_app ; cp config/secrets.example.yml config/secrets.yml )
 ( cd interactive_app ; bundle exec rake db:migrate --trace )
 ( cd interactive_app ; bundle exec rake db:test:prepare --trace )
-( cd interactive_app ; cp ../smashing-template/test/example_spec.rb spec/example_spec.rb )
-( cd interactive_app ; cp ../smashing-template/test/example.feature features/example.feature )
-( cd interactive_app ; cp ../smashing-template/test/example_steps.rb features/example_steps.rb )
+( cd interactive_app ; cp ../boxcar/test/example_spec.rb spec/example_spec.rb )
+( cd interactive_app ; cp ../boxcar/test/example.feature features/example.feature )
+( cd interactive_app ; cp ../boxcar/test/example_steps.rb features/example_steps.rb )

--- a/template.rb
+++ b/template.rb
@@ -44,4 +44,4 @@ initialize_git
 # -----------------------------
 # COMPLETE
 # -----------------------------
-puts "\nSmashing-Template successfully created!"
+puts "\nBoxcar template successfully created!"


### PR DESCRIPTION
## Why?
- To specify Rails version in order to avoid incompatibilities with Rails 5 (pending fix in Rails)
## What Changed?
- Updated template name throughout
- Modified command both in README and in test files to use Rails version 4.2.5
