### PR TITLE
Fixes rubocop bug

### DIFF
--- a/lib/gem_configurator.rb
+++ b/lib/gem_configurator.rb
@@ -55,7 +55,8 @@ def rubocop_config
     examples = RSpec.world.filtered_examples.values.flatten
     if examples.none?(&:exception)
       system("echo '\n' && bundle exec rubocop")
-      exit $? if $? != 0
+      exitstatus = $?.exitstatus
+      exit exitstatus if exitstatus.nonzero?
     end
   end
       RUBY


### PR DESCRIPTION
### Why?

If you run `rspec` and have linting errors, you will see the following error: `spec/spec_helper.rb:31:in exit: no implicit conversion of Process::Status into Integer (TypeError)`.
### What Changed?
- Check the process status code not the process status object
