### PR TITLE
Bug/precompile assets

### DIFF
--- a/lib/file_modifier.rb
+++ b/lib/file_modifier.rb
@@ -41,8 +41,8 @@ def remove_turbolinks
 end
 
 def remove_require_jquery
-  gsub_file 'app/assets/javascripts/application.js', /= require turbolinks/, ''
-  gsub_file 'app/assets/javascripts/application.js', /= require turbolinks/, ''
+  gsub_file 'app/assets/javascripts/application.js', /= require jquery\S+/, ''
+  gsub_file 'app/assets/javascripts/application.js', /= require jquery/, ''
 end
 
 def remove_test_dir

--- a/lib/file_modifier.rb
+++ b/lib/file_modifier.rb
@@ -40,6 +40,11 @@ def remove_turbolinks
   gsub_file 'app/views/layouts/application.html.erb', /, 'data-turbolinks-track' => true/, ""
 end
 
+def remove_require_jquery
+  gsub_file 'app/assets/javascripts/application.js', /= require turbolinks/, ''
+  gsub_file 'app/assets/javascripts/application.js', /= require turbolinks/, ''
+end
+
 def remove_test_dir
   remove_dir "test"
 end

--- a/lib/installer.rb
+++ b/lib/installer.rb
@@ -6,6 +6,7 @@ end
 
 def api_with_admin_install
   remove_turbolinks
+  remove_require_jquery
   devise_auth?
   cucumber_capybara?
   smashing_docs?


### PR DESCRIPTION
## Why?
- The command $ rake assets:precompile was failing in the api_with_admin template version
## What Changed?
- For this template type specifically, removed require_jquery from javascript file
