### PR TITLE
Change all references of 4.2.7 to 4.2.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Boxcar is the Rails application template used at
 ## Requirements
 This template is compatible with:
   - Rails 5.0.0
-  - Rails 4.2.7
+  - Rails 4.2.7.1
 
 The template currently assumes:
   - PostgreSQL
@@ -32,10 +32,10 @@ rails new [app_name] -m boxcar/template.rb -B
 
 To use Rails 4, do the following:
 ```
-rails _4.2.7_ new [app_name] -m boxcar/template.rb -B
+rails _4.2.7.1_ new [app_name] -m boxcar/template.rb -B
 ```
 
-If you run into an issue with Rails 4.2.7, run ```gem install rails -v 4.2.7``` to ensure you have access to this version of Rails.
+If you run into an issue with Rails 4.2.7.1, run ```gem install rails -v 4.2.7.1``` to ensure you have access to this version of Rails.
 
 Note that the ``-B`` is optional and equivalent to ``--skip-bundle``. Since there is a bundle install command inside the template, the final bundle when creating a new Rails app is unnecessary.
 


### PR DESCRIPTION
### Why?
* This should have been part of my last PR.
* Boxcar now uses `4.2.7.1` and should reflect that in the README
### What changed?
* Replaced all occurrences of `4.2.7` with `4.2.7.1`