### PR TITLE
gitignore vendor/ruby

### DIFF
--- a/lib/file_modifier.rb
+++ b/lib/file_modifier.rb
@@ -24,6 +24,7 @@ config/database.yml
 # Ignore .DS_Store files
 .DS_Store
 */.DS_Store
+vendor/ruby
     EOF
   end
 end


### PR DESCRIPTION
Vendoring gems is something that some rubyists do, it helps to have `vendor/ruby` in the gemfile by default.