### PR TITLE
Disable simplecov by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,11 @@ And testing gems including:
 * [Rubocop](https://github.com/bbatsov/rubocop) for linting
 * [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) for common RSpec matchers
 * [Smashing Docs](https://github.com/thoughtbot/shoulda-matchers) for API documentation
+
+## SimpleCov
+Boxcar installs and configures simplecov to run when you set the `GENERATE_COVERAGE` env variable to `true`
+
+```
+GENERATE_COVERAGE=true rspec /path/to/spec.rb
+```
+

--- a/lib/gem_configurator.rb
+++ b/lib/gem_configurator.rb
@@ -47,8 +47,10 @@ def code_climate_config
   inside 'spec' do
     inject_into_file 'spec_helper.rb', after: "# users commonly want.\n" do
       <<-RUBY
-require 'simplecov'
-SimpleCov.start 'rails'
+if ENV['GENERATE_COVERAGE'] == 'true'
+  require 'simplecov'
+  SimpleCov.start 'rails'
+end
       RUBY
     end
   end


### PR DESCRIPTION
We should not configure rails apps to run simplecov by default. This makes it so you must set the `GENERATE_COVERAGE` environment variable to `true` to get coverage reports.