### PR TITLE
Update rubocop configs for new rubocop version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,8 @@ rails new [app_name] -m boxcar/template.rb -B
 
 Derek is in the progress of rewriting boxcar as a gem, instead of a rails template. In the meantime, there are some known bugs and extra steps that need to be taken after generating the app. They are as follows:
 - Gemfile updates
-  - Change `gem 'pg'` to `gem 'pg', "~> 0.21.0"`
   - Change `factory_girl_rails` to `factory_bot_rails`
 - Rename `spec/support/factory_girl.rb` and inside, change `FactoryGirl` to `FactoryBot`
-- Update rubocop configs
-  - Run `bundle exec rubocop`
-  - You'll see stuff like:
-    .rubocop.yml: Style/DotPosition has the wrong namespace - should be Layout
-    .rubocop.yml: Style/FileName has the wrong namespace - should be Naming
-    .rubocop.yml: Style/IndentHeredoc has the wrong namespace - should be Layout
-    .rubocop.yml: Style/PredicateName has the wrong namespace - should be Naming
-    .rubocop.yml: Style/AccessorMethodName has the wrong namespace - should be Naming
-    Warning: unrecognized cop Lint/LiteralInCondition
-    Error: obsolete parameter MaxLineLength (for Style/IfUnlessModifier) found in .rubocop.yml
-    `Style/IfUnlessModifier: MaxLineLength` has been removed. Use `Metrics/LineLength: Max` instead
-  - Fix the errors and warnings it talks about in .rubocop.yml
-  - Run `bundle exec rubocop` again
-  - Fix all linting errors
 - Check `.travis.yml` and `config/database.yml`. Postgres doesn't allow dashes in DB names
 - In `config/database.yml`, upcase the app name in the ENV variable
 - Copy this README template into place and fill it in:

--- a/lib/files/.rubocop.yml
+++ b/lib/files/.rubocop.yml
@@ -3,13 +3,40 @@ AllCops:
   Exclude:
     - "vendor/**/*"
     - "db/schema.rb"
+    - "db/migrate/*"
     - "bin/*"
     - "lib/files/cucumber.rake"
     - "lib/tasks/*"
-    - "db/migrate/*"
+    - "config/initializers/*"
+    - "Vagrantfile"
+    - "Rakefile"
   UseCache: false
 Bundler/OrderedGems:
   Enabled: false
+Layout/TrailingBlankLines:
+  Description: 'Checks trailing blank lines and final newline.'
+  StyleGuide: '#newline-eof'
+  Enabled: false
+Naming/AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  Enabled: false
+Naming/FileName:
+  Description: Use snake_case for source file names.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
+  Enabled: false
+  Exclude: []
+Naming/PredicateName:
+  Description: Check the names of predicate methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
+  Enabled: false
+  NamePrefix:
+  - is_
+  - has_
+  - have_
+  NamePrefixBlacklist:
+  - is_
+  Exclude:
+  - spec/**/*
 Style/CollectionMethods:
   Description: Preferred collection methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size
@@ -19,7 +46,7 @@ Style/CollectionMethods:
     collect!: map!
     find_all: select
     reduce: inject
-Style/DotPosition:
+Layout/DotPosition:
   Description: Checks the position of the dot in multi-line method calls.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
   Enabled: true
@@ -31,11 +58,6 @@ Style/AsciiComments:
   Enabled: false
 Style/Lambda:
   Enabled: false
-Style/FileName:
-  Description: Use snake_case for source file names.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
-  Enabled: false
-  Exclude: []
 Style/GuardClause:
   Description: Check for conditionals that can be replaced with guard clauses
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
@@ -44,9 +66,6 @@ Style/GuardClause:
 Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
-  Enabled: false
-  MaxLineLength: 100
-Style/IndentHeredoc:
   Enabled: false
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.
@@ -65,18 +84,6 @@ Style/PercentLiteralDelimiters:
     "%w": "()"
     "%W": "()"
     "%x": "()"
-Style/PredicateName:
-  Description: Check the names of predicate methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
-  Enabled: false
-  NamePrefix:
-  - is_
-  - has_
-  - have_
-  NamePrefixBlacklist:
-  - is_
-  Exclude:
-  - spec/**/*
 Style/RaiseArgs:
   Description: Checks the arguments passed to raise/fail.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#exception-class-messages
@@ -112,24 +119,33 @@ Style/SingleLineMethods:
   AllowIfMethodIsEmpty: true
 Style/StringLiterals:
   Enabled: false
+  EnforcedStyle: double_quotes
 Style/StringLiteralsInInterpolation:
   Description: Checks if uses of quotes inside expressions in interpolated strings
     match the configured preference.
   Enabled: false
   EnforcedStyle: single_quotes
   SupportedStyles:
-  - single_quotes
   - double_quotes
+  - single_quotes
 Style/TrailingCommaInArguments:
   Description: Checks for trailing comma in argument lists.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
   Enabled: false
   EnforcedStyleForMultiline: no_comma
+  SupportedStylesForMultiline:
+  - comma
+  - consistent_comma
+  - no_comma
 Style/TrailingCommaInLiteral:
   Description: Checks for trailing comma in array and hash literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
   Enabled: false
   EnforcedStyleForMultiline: no_comma
+  SupportedStylesForMultiline:
+  - comma
+  - consistent_comma
+  - no_comma
 Metrics/AbcSize:
   Description: A calculated magnitude based on number of assignments, branches, and
     conditions.
@@ -173,6 +189,7 @@ Metrics/LineLength:
   Max: 100
   # To make it possible to copy or click on URIs in the code, we allow lines
   # contaning a URI to be longer than Max.
+  IgnoredPatterns: ['\A\s*#']
   AllowURI: true
   URISchemes:
     - http
@@ -189,9 +206,6 @@ Style/ClassAndModuleChildren:
 Style/InlineComment:
   Description: Avoid inline comments.
   Enabled: false
-Style/AccessorMethodName:
-  Description: Check the naming of accessor methods for get_/set_.
-  Enabled: fals
 Style/Alias:
   Description: Use alias_method instead of alias.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
@@ -242,15 +256,14 @@ Style/WhenThen:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
+Style/FormatStringToken:
+  Enabled: false
 Lint/EachWithObjectArgument:
   Description: Check for immutable argument given to each_with_object.
   Enabled: true
 Lint/HandleExceptions:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
-  Enabled: false
-Lint/LiteralInCondition:
-  Description: Checks of literals used in conditions.
   Enabled: false
 Lint/LiteralInInterpolation:
   Description: Checks for literals used in interpolation.
@@ -273,3 +286,10 @@ Rails/ScopeArgs:
   Enabled: true
 Rails/TimeZone:
   Enabled: true
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - staging
+    - development
+    - test
+

--- a/lib/files/Gemfile
+++ b/lib/files/Gemfile
@@ -8,7 +8,7 @@ end
 
 gem 'rails', '~> 5.1.3'
 # Use postgresql as the database for Active Record
-gem 'pg'
+gem 'pg', "~> 0.21.0"
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets


### PR DESCRIPTION
### Why?
  - Updating Rubocop configs is annoying
  - Re-bundling to get the correct postgres version is also annoying

### What Changed?
  - Updated Rubocop config to reflect new rules
  - Specified Postgres version in Gemfile