### PR TITLE
Add an env variable for disabling rubocop, brakeman, and bundle-audit checks

### DIFF
--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -12,7 +12,7 @@ RSpec.configure do |config|
       "brakeman -q -w2 -z --no-summary",
       "bundle-audit --update"
     ]
-    if examples.none?(&:exception)
+    if examples.none?(&:exception) && ENV['DISABLE_POSTCHECKS'] != 'true'
       after_hooks.each do |hook_command|
         system("echo ' ' && #{hook_command}")
         exitstatus = $?.exitstatus


### PR DESCRIPTION
### Why?

- Sometimes it's annoying to have to wait for the linter (and other steps) every time you run specs locally

### What changed?

- Add support for passing a `DISABLE_POSTCHECKS` environment variable, which tells rspec to skip these checks