### PR TITLE
Remove database.yml copy

### DIFF
--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -28,7 +28,6 @@ git clone <REPO_URL>
 cd <APP_DIR>
 bundle install
 cp config/secrets.example.yml config/secrets.yml
-cp config/database.example.yml config/database.yml
 bundle exec rails db:setup
 ```
 


### PR DESCRIPTION
## Why?

- database.yml is no longer gitignored

## What Changed?

- Remove `cp config/database.example.yml config/database.yml` from generated readme
