### PR TITLE
[ISSUE #107] fill in yarn version

### DIFF
--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -2,8 +2,9 @@ language: ruby
 rvm:
   - <%= Boxcar::RUBY_VERSION %>
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version version-number
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
   - export PATH="$HOME/.yarn/bin:$PATH"
+  - yarn install
 cache: yarn
 before_script:
   - cp config/secrets.example.yml config/secrets.yml


### PR DESCRIPTION
## Why?
- ISSUE #107  
- Yarn configuration in Boxcar was causing Travis CI to fail when attempting to do PRs. 

## What Changed?
- Hard codes version `1.7.0` into the curl command to install `yarnpkg`
- Adds `yarn install` as the final `before_install` command in `.travis.yml` so TCI can install `yarn`.
