### PR TITLE
[ISSUE #106] change wget for curl

### DIFF
--- a/lib/boxcar/app_builder.rb
+++ b/lib/boxcar/app_builder.rb
@@ -196,11 +196,13 @@ module Boxcar
     end
 
     def create_eslint_config
-      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/.eslintrc -o ../../.eslintrc"
+      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/.eslintrc 
+        -o ../../.eslintrc"
     end
 
     def create_stylelint_config
-      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/stylelint.config.js -o ../../stylelint.config.js"
+      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/stylelint.config.js 
+        -o ../../stylelint.config.js"
     end
 
     def setup_package_json

--- a/lib/boxcar/app_builder.rb
+++ b/lib/boxcar/app_builder.rb
@@ -196,11 +196,13 @@ module Boxcar
     end
 
     def create_eslint_config
-      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/.eslintrc -o ../../.eslintrc"
+      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/.eslintrc
+        -o ../../.eslintrc"
     end
 
     def create_stylelint_config
-      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/stylelint.config.js -o ../../stylelint.config.js"
+      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/stylelint.config.js
+        -o ../../stylelint.config.js"
     end
 
     def setup_package_json

--- a/lib/boxcar/app_builder.rb
+++ b/lib/boxcar/app_builder.rb
@@ -196,11 +196,11 @@ module Boxcar
     end
 
     def create_eslint_config
-      run "wget https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/.eslintrc"
+      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/.eslintrc -o ../../.eslintrc"
     end
 
     def create_stylelint_config
-      run "wget https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/stylelint.config.js"
+      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/stylelint.config.js -o ../../stylelint.config.js"
     end
 
     def setup_package_json


### PR DESCRIPTION
## Why?
* Issue #106 
* wget isn't installed by default on Mac
## What Changed?
* updated `create_eslint_config` and `create_stylelint_config` functions to use curl instead of wget, and output the respective files in the app's root
