### PR TITLE
Change wget for curl in app_builder.rb

### DIFF
--- a/lib/boxcar/app_builder.rb
+++ b/lib/boxcar/app_builder.rb
@@ -196,11 +196,12 @@ module Boxcar
     end
 
     def create_eslint_config
-      run "wget https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/.eslintrc"
+      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/.eslintrc -O"
     end
 
     def create_stylelint_config
-      run "wget https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/stylelint.config.js"
+      url = "https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/stylelint.config.js"
+      run "curl #{url} -O"
     end
 
     def setup_package_json


### PR DESCRIPTION
## Why?
* Issue #106 
* wget isn't installed by default on Mac, so the command wasn't working for all users
## What Changed?
* updated `create_eslint_config` and `create_stylelint_config` functions to use curl instead of wget
