### PR TITLE
Added rspec_examples.txt to gitignore

### DIFF
--- a/templates/boxcar_gitignore
+++ b/templates/boxcar_gitignore
@@ -14,3 +14,4 @@
 /tmp/*
 /yarn-error.log
 ER_Model.pdf
+spec/rspec_examples.txt


### PR DESCRIPTION
## Why?

- This file is auto-generated by new versions of rspec. We don't need to commit it

## What Changed?

- Added rspec_examples.txt to gitignore