### PR TITLE
Fix Uninitialized constant errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,11 +11,11 @@ AllCops:
 
 Rails:
   Enabled: false
-
 RSpec/DescribeClass:
   Enabled: false
 RSpec/BeforeAfterAll:
   Enabled: false
-
+Style/ClassAndModuleChildren:
+  Enabled: false
 Style/MutableConstant:
   Enabled: false

--- a/lib/boxcar/app_builder.rb
+++ b/lib/boxcar/app_builder.rb
@@ -4,318 +4,320 @@
 # app. For example, the readme method is responsible for creating the readme file. Since we're
 # inheriting from Rails::AppBuilder, we have a lot of those building blocks set up for us already.
 # We can override those methods to customize how they work, or we can create new ones.
-class Boxcar::AppBuilder < Rails::AppBuilder
-  def gitignore
-    copy_file "boxcar_gitignore", ".gitignore"
-  end
+module Boxcar
+  class AppBuilder < Rails::AppBuilder
+    def gitignore
+      copy_file "boxcar_gitignore", ".gitignore"
+    end
 
-  def readme
-    template "README.md.erb", "README.md"
-  end
+    def readme
+      template "README.md.erb", "README.md"
+    end
 
-  def configure_travis
-    template "travis.yml.erb", ".travis.yml"
-  end
+    def configure_travis
+      template "travis.yml.erb", ".travis.yml"
+    end
 
-  def ruby_version
-    template ".ruby-version.erb", ".ruby-version"
-  end
+    def ruby_version
+      template ".ruby-version.erb", ".ruby-version"
+    end
 
-  def gemfile
-    template "Gemfile.erb", "Gemfile", gem_configs
-  end
+    def gemfile
+      template "Gemfile.erb", "Gemfile", gem_configs
+    end
 
-  def database_yml
-    template "database.yml.erb", "config/database.yml"
-  end
+    def database_yml
+      template "database.yml.erb", "config/database.yml"
+    end
 
-  def create_secrets_example
-    copy_file "secrets.example.yml", "config/secrets.example.yml"
-    run "cp config/secrets.example.yml config/secrets.yml"
-  end
+    def create_secrets_example
+      copy_file "secrets.example.yml", "config/secrets.example.yml"
+      run "cp config/secrets.example.yml config/secrets.yml"
+    end
 
-  def generate_rspec
-    generate "rspec:install"
-    install_specs
-  end
+    def generate_rspec
+      generate "rspec:install"
+      install_specs
+    end
 
-  def install_specs
-    copy_file "seed_spec.rb", "spec/seeds/seed_spec.rb"
-  end
+    def install_specs
+      copy_file "seed_spec.rb", "spec/seeds/seed_spec.rb"
+    end
 
-  def configure_rspec
-    remove_file "spec/rails_helper.rb"
-    remove_file "spec/spec_helper.rb"
-    copy_file "rails_helper.rb", "spec/rails_helper.rb"
-    copy_file "spec_helper.rb", "spec/spec_helper.rb"
-  end
+    def configure_rspec
+      remove_file "spec/rails_helper.rb"
+      remove_file "spec/spec_helper.rb"
+      copy_file "rails_helper.rb", "spec/rails_helper.rb"
+      copy_file "spec_helper.rb", "spec/spec_helper.rb"
+    end
 
-  def create_database_cleaner_config
-    copy_file "database_cleaner.rb", "spec/support/database_cleaner.rb"
-  end
+    def create_database_cleaner_config
+      copy_file "database_cleaner.rb", "spec/support/database_cleaner.rb"
+    end
 
-  def create_factory_bot_config
-    copy_file "factory_bot.rb", "spec/support/factory_bot.rb"
-  end
+    def create_factory_bot_config
+      copy_file "factory_bot.rb", "spec/support/factory_bot.rb"
+    end
 
-  def create_shoulda_matchers_config
-    copy_file "shoulda_matchers.rb", "spec/support/shoulda_matchers.rb"
-  end
+    def create_shoulda_matchers_config
+      copy_file "shoulda_matchers.rb", "spec/support/shoulda_matchers.rb"
+    end
 
-  def create_request_helpers_config
-    copy_file "request_helpers.rb", "spec/support/request_helpers.rb"
-  end
+    def create_request_helpers_config
+      copy_file "request_helpers.rb", "spec/support/request_helpers.rb"
+    end
 
-  def install_tape
-    run "tape installer install --no-vagrant"
-    gsub_file "taperole/tape_vars.yml", /app_name:/, "app_name: #{app_name.underscore}"
-  end
+    def install_tape
+      run "tape installer install --no-vagrant"
+      gsub_file "taperole/tape_vars.yml", /app_name:/, "app_name: #{app_name.underscore}"
+    end
 
-  def install_activeadmin
-    generate "active_admin:install --skip-users --skip-comments"
-    split_long_comments "config/initializers/active_admin.rb"
-    gsub_file "app/admin/dashboard.rb", "end # content", "end"
-  end
+    def install_activeadmin
+      generate "active_admin:install --skip-users --skip-comments"
+      split_long_comments "config/initializers/active_admin.rb"
+      gsub_file "app/admin/dashboard.rb", "end # content", "end"
+    end
 
-  def install_devise
-    generate "devise:install"
-    generate "devise User"
-    gsub_file "config/initializers/devise.rb", /# config.secret_key.*/, "# config.secret_key = ''"
-    gsub_file "config/initializers/devise.rb", /# config.pepper.*/, "# config.pepper = ''"
-  end
+    def install_devise
+      generate "devise:install"
+      generate "devise User"
+      gsub_file "config/initializers/devise.rb", /# config.secret_key.*/, "# config.secret_key = ''"
+      gsub_file "config/initializers/devise.rb", /# config.pepper.*/, "# config.pepper = ''"
+    end
 
-  def install_devise_token_auth
-    generate "devise_token_auth:install User auth"
-    # This does two things different from the default.
-    # 1. It inherits from ApplicationRecord instead of ActiveRecord::Base
-    # 2. It doesn't include omniauthable by default
-    copy_file "user.rb", "app/model/user.rb"
-    copy_file "users_factory.rb", "spec/factories/users_factory.rb"
-  end
+    def install_devise_token_auth
+      generate "devise_token_auth:install User auth"
+      # This does two things different from the default.
+      # 1. It inherits from ApplicationRecord instead of ActiveRecord::Base
+      # 2. It doesn't include omniauthable by default
+      copy_file "user.rb", "app/model/user.rb"
+      copy_file "users_factory.rb", "spec/factories/users_factory.rb"
+    end
 
-  def create_routes
-    remove_file "config/routes.rb"
-    template "routes.rb.erb", "config/routes.rb", gem_configs
-  end
+    def create_routes
+      remove_file "config/routes.rb"
+      template "routes.rb.erb", "config/routes.rb", gem_configs
+    end
 
-  def create_github_markdown
-    copy_file "pull_request_template.md", ".github/pull_request_template.md"
-  end
+    def create_github_markdown
+      copy_file "pull_request_template.md", ".github/pull_request_template.md"
+    end
 
-  def create_devise_token_auth_helpers
-    api_controller
-    devise_controller
-    render_helper
-    spec_request_helper
-    spec_auth_helpers
-    auth_specs
-  end
+    def create_devise_token_auth_helpers
+      api_controller
+      devise_controller
+      render_helper
+      spec_request_helper
+      spec_auth_helpers
+      auth_specs
+    end
 
-  def auth_specs
-    copy_file "sign_in_spec.rb", "spec/requests/api/v1/users/sign_in_spec.rb"
-  end
+    def auth_specs
+      copy_file "sign_in_spec.rb", "spec/requests/api/v1/users/sign_in_spec.rb"
+    end
 
-  def spec_auth_helpers
-    copy_file "auth_helper.rb", "spec/support/auth_helper.rb"
-    copy_file "valid_sign_in_credentials.rb", "spec/support/valid_sign_in_credentials.rb"
-    copy_file "valid_sign_in.rb", "spec/support/valid_sign_in.rb"
-  end
+    def spec_auth_helpers
+      copy_file "auth_helper.rb", "spec/support/auth_helper.rb"
+      copy_file "valid_sign_in_credentials.rb", "spec/support/valid_sign_in_credentials.rb"
+      copy_file "valid_sign_in.rb", "spec/support/valid_sign_in.rb"
+    end
 
-  def spec_request_helper
-    copy_file "requests.rb", "spec/support/requests.rb"
-  end
+    def spec_request_helper
+      copy_file "requests.rb", "spec/support/requests.rb"
+    end
 
-  def render_helper
-    copy_file "render_helper.rb", "app/controllers/concerns/render_helper.rb"
-  end
+    def render_helper
+      copy_file "render_helper.rb", "app/controllers/concerns/render_helper.rb"
+    end
 
-  def create_erd_config
-    copy_file ".erdconfig", ".erdconfig"
-  end
+    def create_erd_config
+      copy_file ".erdconfig", ".erdconfig"
+    end
 
-  def devise_controller
-    copy_file "devise_token_auth_response_serializer.rb",
-              "app/controllers/concerns/devise_token_auth_response_serializer.rb"
-    copy_file "registrations_controller.rb",
-              "app/controllers/api/v1/users/registration_controller.rb"
-    copy_file "sessions_controller.rb", "app/controllers/api/v1/users/sessions_controller.rb"
-  end
+    def devise_controller
+      copy_file "devise_token_auth_response_serializer.rb",
+                "app/controllers/concerns/devise_token_auth_response_serializer.rb"
+      copy_file "registrations_controller.rb",
+                "app/controllers/api/v1/users/registration_controller.rb"
+      copy_file "sessions_controller.rb", "app/controllers/api/v1/users/sessions_controller.rb"
+    end
 
-  def api_controller
-    copy_file "api_controller.rb", "app/controllers/api/v1/api_controller.rb"
-    copy_file "application_controller.rb", "app/controllers/api/v1/application_controller.rb"
-  end
+    def api_controller
+      copy_file "api_controller.rb", "app/controllers/api/v1/api_controller.rb"
+      copy_file "application_controller.rb", "app/controllers/api/v1/application_controller.rb"
+    end
 
-  def setup_database
-    run "rails db:create"
-  end
+    def setup_database
+      run "rails db:create"
+    end
 
-  def migrate_database
-    run "rails db:migrate"
-  end
+    def migrate_database
+      run "rails db:migrate"
+    end
 
-  def setup_annotate
-    copy_file "auto_annotate_models.rake", "lib/tasks/auto_annotate_models.rake"
-  end
+    def setup_annotate
+      copy_file "auto_annotate_models.rake", "lib/tasks/auto_annotate_models.rake"
+    end
 
-  def setup_action_mailer
-    development_action_mailer_config = <<~CONFIG
+    def setup_action_mailer
+      development_action_mailer_config = <<~CONFIG
 
-      config.action_mailer.delivery_method = :letter_opener
-      config.action_mailer.perform_deliveries = true
+        config.action_mailer.delivery_method = :letter_opener
+        config.action_mailer.perform_deliveries = true
 
-      config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+        config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
-    CONFIG
+      CONFIG
 
-    insert_into_file "config/environments/development.rb",
-                     development_action_mailer_config,
-                     before: "# Don't care if the mailer can't send."
+      insert_into_file "config/environments/development.rb",
+                       development_action_mailer_config,
+                       before: "# Don't care if the mailer can't send."
 
-    production_action_mailer_config = <<~CONFIG
+      production_action_mailer_config = <<~CONFIG
 
-      config.action_mailer.default_url_options = {
-        host: Rails.application.secrets.mailgun_domain
-      }
+        config.action_mailer.default_url_options = {
+          host: Rails.application.secrets.mailgun_domain
+        }
 
-      config.action_mailer.delivery_method = :mailgun
+        config.action_mailer.delivery_method = :mailgun
 
-      config.action_mailer.mailgun_settings = {
-        api_key: Rails.application.secrets.mailgun_api_key,
-        domain: Rails.application.secrets.mailgun_domain
-      }
+        config.action_mailer.mailgun_settings = {
+          api_key: Rails.application.secrets.mailgun_api_key,
+          domain: Rails.application.secrets.mailgun_domain
+        }
 
-    CONFIG
+      CONFIG
 
-    insert_into_file "config/environments/production.rb",
-                     production_action_mailer_config,
-                     before: "config.action_mailer.perform_caching = false"
-  end
+      insert_into_file "config/environments/production.rb",
+                       production_action_mailer_config,
+                       before: "config.action_mailer.perform_caching = false"
+    end
 
-  def create_rubocop_config
-    copy_file ".rubocop.yml", ".rubocop.yml"
-  end
+    def create_rubocop_config
+      copy_file ".rubocop.yml", ".rubocop.yml"
+    end
 
-  def create_eslint_config
-    run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/.eslintrc -O"
-  end
+    def create_eslint_config
+      run "curl https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/.eslintrc -O"
+    end
 
-  def create_stylelint_config
-    url = "https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/stylelint.config.js"
-    run "curl #{url} -O"
-  end
+    def create_stylelint_config
+      url = "https://raw.githubusercontent.com/smashingboxes/web-boilerplate/master/stylelint.config.js"
+      run "curl #{url} -O"
+    end
 
-  def setup_package_json
-    remove_file "package.json"
-    template "package.json.erb", "package.json"
-  end
+    def setup_package_json
+      remove_file "package.json"
+      template "package.json.erb", "package.json"
+    end
 
-  def rubocop_autocorrect
-    run "rubocop -a", capture: true
-  end
+    def rubocop_autocorrect
+      run "rubocop -a", capture: true
+    end
 
-  def cleanup_other_rubocop_violations
-    split_long_comments "config/initializers/backtrace_silencers.rb"
-    split_long_comments "config/environments/production.rb"
-    split_long_comments "db/seeds.rb"
-  end
+    def cleanup_other_rubocop_violations
+      split_long_comments "config/initializers/backtrace_silencers.rb"
+      split_long_comments "config/environments/production.rb"
+      split_long_comments "db/seeds.rb"
+    end
 
-  def cleanup_eslint_violations
-    eslint_disable_file "app/assets/javascripts/cable.js"
-  end
+    def cleanup_eslint_violations
+      eslint_disable_file "app/assets/javascripts/cable.js"
+    end
 
-  # rubocop:disable Style/ClassVars
-  # These are stored in class variables because the builder gets instantiated multiple times,
-  # and we want to remember those preferences across instantiations
-  def boxcar_configs
-    @@boxcar_configs ||= begin
-      api_app = preference?(:api_only, "Is this an API only app? (y/N)")
-      gems = {}
-      if api_app
-        gems[:devise] = false
-        gems[:devise_token_auth] =
-          preference?(:devise_token_auth, "Install devise_token_auth? (y/N)")
-        gems[:active_model_serializers] = true
-      else
-        gems[:devise] = preference?(:devise, "Install devise? (y/N)")
-        gems[:devise_token_auth] = false
+    # rubocop:disable Style/ClassVars
+    # These are stored in class variables because the builder gets instantiated multiple times,
+    # and we want to remember those preferences across instantiations
+    def boxcar_configs
+      @@boxcar_configs ||= begin
+        api_app = preference?(:api_only, "Is this an API only app? (y/N)")
+        gems = {}
+        if api_app
+          gems[:devise] = false
+          gems[:devise_token_auth] =
+            preference?(:devise_token_auth, "Install devise_token_auth? (y/N)")
+          gems[:active_model_serializers] = true
+        else
+          gems[:devise] = preference?(:devise, "Install devise? (y/N)")
+          gems[:devise_token_auth] = false
+        end
+        gems[:activeadmin] = preference?(:activeadmin, "Install Active Admin? (y/N)")
+        gems[:tape] = !options[:skip_tape]
+
+        {
+          api_app: api_app,
+          gems: gems
+        }
       end
-      gems[:activeadmin] = preference?(:activeadmin, "Install Active Admin? (y/N)")
-      gems[:tape] = !options[:skip_tape]
-
-      {
-        api_app: api_app,
-        gems: gems
-      }
     end
-  end
-  # rubocop:enable Style/ClassVars
+    # rubocop:enable Style/ClassVars
 
-  def gem_configs
-    boxcar_configs[:gems]
-  end
-
-  private
-
-  def eslint_disable_file(filename)
-    prepend_to_file filename, "/* eslint-disable */"
-    append_to_file filename, "/* eslint-enable */\n"
-  end
-
-  def split_long_comments(filename)
-    gsub_file filename, /(.){100,}/ do |match|
-      split_long_comment_string(match)
+    def gem_configs
+      boxcar_configs[:gems]
     end
-  end
 
-  def split_long_comment_string(line)
-    limit = 100
+    private
 
-    # Find any comment lines, and capture the start of the line
-    matches = line.match(/(\A\s*\#)[^{]/)
-    return line unless matches
+    def eslint_disable_file(filename)
+      prepend_to_file filename, "/* eslint-disable */"
+      append_to_file filename, "/* eslint-enable */\n"
+    end
 
-    # This will be the "  #" part. There might be multiple spaces before the pound symbol.
-    line_prefix = matches[0]
-    comment_limit = limit - line_prefix.length
-
-    # Take all content after the pound symbol and following space(s)
-    comment = line.split(/#\s*/)[1]
-    # Split that content into an array of words
-    words = comment.split(" ")
-    # Build up an array of new lines, where each line won't be longer than the line-length limit
-    lines = words.reduce([line_prefix]) do |memo, word|
-      previous_lines = memo[0..-2] # all lines but the current one
-      current_line = memo.last
-      word_appended = "#{current_line} #{word}"
-      # if the line (with the current word appended) is too long, start a new line, prefixed
-      # with a "#" and the right number spaces before it
-      if word_appended.length > comment_limit
-        next_line = "#{line_prefix} #{word}"
-        memo.concat([next_line])
-      else
-        previous_lines.concat([word_appended])
+    def split_long_comments(filename)
+      gsub_file filename, /(.){100,}/ do |match|
+        split_long_comment_string(match)
       end
     end
 
-    lines.join("\n")
-  end
+    def split_long_comment_string(line)
+      limit = 100
 
-  # If a flag was given, return that. Otherwise, ask the user with `yes?`
-  def preference?(flag, question)
-    options[flag].nil? ? yes?(question) : options[flag]
-  end
+      # Find any comment lines, and capture the start of the line
+      matches = line.match(/(\A\s*\#)[^{]/)
+      return line unless matches
 
-  # This is neccessary because the default `run` outputs in a different stream for some reason,
-  # which was creating unwanted output in tests
-  def run(command, capture: false)
-    output = super(command, capture: true)
-    say(output) unless capture
-    output
-  end
+      # This will be the "  #" part. There might be multiple spaces before the pound symbol.
+      line_prefix = matches[0]
+      comment_limit = limit - line_prefix.length
 
-  # This is necessary because the default `generate` runs the default `run` instead of our run
-  def generate(command)
-    run "rails generate #{command}"
+      # Take all content after the pound symbol and following space(s)
+      comment = line.split(/#\s*/)[1]
+      # Split that content into an array of words
+      words = comment.split(" ")
+      # Build up an array of new lines, where each line won't be longer than the line-length limit
+      lines = words.reduce([line_prefix]) do |memo, word|
+        previous_lines = memo[0..-2] # all lines but the current one
+        current_line = memo.last
+        word_appended = "#{current_line} #{word}"
+        # if the line (with the current word appended) is too long, start a new line, prefixed
+        # with a "#" and the right number spaces before it
+        if word_appended.length > comment_limit
+          next_line = "#{line_prefix} #{word}"
+          memo.concat([next_line])
+        else
+          previous_lines.concat([word_appended])
+        end
+      end
+
+      lines.join("\n")
+    end
+
+    # If a flag was given, return that. Otherwise, ask the user with `yes?`
+    def preference?(flag, question)
+      options[flag].nil? ? yes?(question) : options[flag]
+    end
+
+    # This is neccessary because the default `run` outputs in a different stream for some reason,
+    # which was creating unwanted output in tests
+    def run(command, capture: false)
+      output = super(command, capture: true)
+      say(output) unless capture
+      output
+    end
+
+    # This is necessary because the default `generate` runs the default `run` instead of our run
+    def generate(command)
+      run "rails generate #{command}"
+    end
   end
 end

--- a/lib/boxcar/commands/boxcar.rb
+++ b/lib/boxcar/commands/boxcar.rb
@@ -2,13 +2,17 @@
 
 require "thor"
 
-class Boxcar::Commands::Boxcar < Thor
-  map %w[--version -v] => :__print_version
+module Boxcar
+  module Commands
+    class Boxcar < Thor
+      map %w[--version -v] => :__print_version
 
-  desc "--version, -v", "print the version"
-  def __print_version
-    puts Boxcar::VERSION
+      desc "--version, -v", "print the version"
+      def __print_version
+        puts Boxcar::VERSION
+      end
+
+      register New, "new", "new", "create a new rails app"
+    end
   end
-
-  register New, "new", "new", "create a new rails app"
 end

--- a/lib/boxcar/commands/new.rb
+++ b/lib/boxcar/commands/new.rb
@@ -15,143 +15,147 @@ require "rails/generators/rails/app/app_generator"
 #
 # Adding new functionality should be placed in the boxcar_customization function.  Please invoke
 # the new functionality like the commands in boxcar_customization function.
-class Boxcar::Commands::New < Rails::Generators::AppGenerator
-  class_option :skip_test, type: :boolean, default: true, desc: "Skip Test Unit"
-  class_option :skip_spring, type: :boolean, default: true, desc: "Skip Spring"
-  class_option :skip_tape, type: :boolean, default: false, desc: "Skip setting up the tape gem"
-  class_option :skip_turbolinks, type: :boolean, default: true, desc: "Skip Turbolinks"
-  class_option :api_only, type: :boolean, desc: "API only app?"
-  class_option :activeadmin, type: :boolean, desc: "Install active admin?"
-  class_option :devise, type: :boolean, desc: "Install devise?"
-  class_option :devise_token_auth, type: :boolean, desc: "Install devise_token_auth?"
+module Boxcar
+  module Commands
+    class New < Rails::Generators::AppGenerator
+      class_option :skip_test, type: :boolean, default: true, desc: "Skip Test Unit"
+      class_option :skip_spring, type: :boolean, default: true, desc: "Skip Spring"
+      class_option :skip_tape, type: :boolean, default: false, desc: "Skip setting up the tape gem"
+      class_option :skip_turbolinks, type: :boolean, default: true, desc: "Skip Turbolinks"
+      class_option :api_only, type: :boolean, desc: "API only app?"
+      class_option :activeadmin, type: :boolean, desc: "Install active admin?"
+      class_option :devise, type: :boolean, desc: "Install devise?"
+      class_option :devise_token_auth, type: :boolean, desc: "Install devise_token_auth?"
 
-  # We're overriding run_after_bundle_callbacks because it's almost the last thing that the
-  # rails generator does, and it's where we want to do our custom behavior
-  def run_after_bundle_callbacks
-    super
-    invoke :boxcar_customization
-  end
+      # We're overriding run_after_bundle_callbacks because it's almost the last thing that the
+      # rails generator does, and it's where we want to do our custom behavior
+      def run_after_bundle_callbacks
+        super
+        invoke :boxcar_customization
+      end
 
-  def boxcar_customization
-    # Extensions go here
-    invoke :setup_ruby_version
-    invoke :setup_secrets
-    invoke :setup_test_environment
-    invoke :setup_tape
-    invoke :setup_activeadmin
-    invoke :setup_database
-    invoke :setup_devise
-    invoke :setup_annotate
-    invoke :setup_action_mailer
-    invoke :migrate_database
-    invoke :setup_github_template
-    invoke :setup_routes
-    invoke :setup_erd_template
-    invoke :setup_package_json
-    invoke :setup_linters # This line should be last
-  end
+      def boxcar_customization
+        # Extensions go here
+        invoke :setup_ruby_version
+        invoke :setup_secrets
+        invoke :setup_test_environment
+        invoke :setup_tape
+        invoke :setup_activeadmin
+        invoke :setup_database
+        invoke :setup_devise
+        invoke :setup_annotate
+        invoke :setup_action_mailer
+        invoke :migrate_database
+        invoke :setup_github_template
+        invoke :setup_routes
+        invoke :setup_erd_template
+        invoke :setup_package_json
+        invoke :setup_linters # This line should be last
+      end
 
-  def setup_routes
-    build :create_routes
-  end
+      def setup_routes
+        build :create_routes
+      end
 
-  def setup_secrets
-    say "Setting up secrets"
-    build :create_secrets_example
-  end
+      def setup_secrets
+        say "Setting up secrets"
+        build :create_secrets_example
+      end
 
-  def setup_ruby_version
-    say "Setting up .ruby_version"
-    build :ruby_version
-  end
+      def setup_ruby_version
+        say "Setting up .ruby_version"
+        build :ruby_version
+      end
 
-  def setup_erd_template
-    say "Adding the erd config file"
-    build :create_erd_config
-  end
+      def setup_erd_template
+        say "Adding the erd config file"
+        build :create_erd_config
+      end
 
-  def setup_github_template
-    say "Adding the github template"
-    build :create_github_markdown
-  end
+      def setup_github_template
+        say "Adding the github template"
+        build :create_github_markdown
+      end
 
-  def setup_test_environment
-    say "Setting up the test environment"
-    build :generate_rspec
-    build :configure_rspec
-    build :create_database_cleaner_config
-    build :create_factory_bot_config
-    build :create_shoulda_matchers_config
-    build :create_request_helpers_config
-    build :configure_travis
-  end
+      def setup_test_environment
+        say "Setting up the test environment"
+        build :generate_rspec
+        build :configure_rspec
+        build :create_database_cleaner_config
+        build :create_factory_bot_config
+        build :create_shoulda_matchers_config
+        build :create_request_helpers_config
+        build :configure_travis
+      end
 
-  def setup_tape
-    return unless builder.gem_configs[:tape]
+      def setup_tape
+        return unless builder.gem_configs[:tape]
 
-    say "Setting up tape"
-    build :install_tape
-  end
+        say "Setting up tape"
+        build :install_tape
+      end
 
-  def setup_activeadmin
-    return unless builder.gem_configs[:activeadmin]
+      def setup_activeadmin
+        return unless builder.gem_configs[:activeadmin]
 
-    say "Installing active admin"
-    build :install_activeadmin
-  end
+        say "Installing active admin"
+        build :install_activeadmin
+      end
 
-  def setup_database
-    say "Setting up database"
-    build :setup_database
-  end
+      def setup_database
+        say "Setting up database"
+        build :setup_database
+      end
 
-  def migrate_database
-    say "Migrating database"
-    build :migrate_database
-  end
+      def migrate_database
+        say "Migrating database"
+        build :migrate_database
+      end
 
-  def setup_devise
-    if builder.gem_configs[:devise]
-      say "Installing devise"
-      build :install_devise
-    elsif builder.gem_configs[:devise_token_auth]
-      say "Installing devise_token_auth"
-      build :install_devise_token_auth
-      build :create_devise_token_auth_helpers
+      def setup_devise
+        if builder.gem_configs[:devise]
+          say "Installing devise"
+          build :install_devise
+        elsif builder.gem_configs[:devise_token_auth]
+          say "Installing devise_token_auth"
+          build :install_devise_token_auth
+          build :create_devise_token_auth_helpers
+        end
+      end
+
+      def setup_action_mailer
+        say "Setting up ActionMailer"
+        build :setup_action_mailer
+      end
+
+      def setup_annotate
+        say "Setting up annotate"
+        build :setup_annotate
+      end
+
+      def setup_package_json
+        say "Setting up package.json"
+        build :setup_package_json
+      end
+
+      def setup_linters
+        say "Setting up the linter configs"
+        build :create_rubocop_config
+        build :rubocop_autocorrect
+        build :cleanup_other_rubocop_violations
+        build :create_eslint_config
+        build :cleanup_eslint_violations
+        build :create_stylelint_config
+      end
+
+      protected
+
+      # rubocop:disable Naming/AccessorMethodName
+      # We have no control over this name. It's defined by rails
+      def get_builder_class
+        ::Boxcar::AppBuilder
+      end
+      # rubocop:enable Naming/AccessorMethodName
     end
   end
-
-  def setup_action_mailer
-    say "Setting up ActionMailer"
-    build :setup_action_mailer
-  end
-
-  def setup_annotate
-    say "Setting up annotate"
-    build :setup_annotate
-  end
-
-  def setup_package_json
-    say "Setting up package.json"
-    build :setup_package_json
-  end
-
-  def setup_linters
-    say "Setting up the linter configs"
-    build :create_rubocop_config
-    build :rubocop_autocorrect
-    build :cleanup_other_rubocop_violations
-    build :create_eslint_config
-    build :cleanup_eslint_violations
-    build :create_stylelint_config
-  end
-
-  protected
-
-  # rubocop:disable Naming/AccessorMethodName
-  # We have no control over this name. It's defined by rails
-  def get_builder_class
-    ::Boxcar::AppBuilder
-  end
-  # rubocop:enable Naming/AccessorMethodName
 end


### PR DESCRIPTION
## Why?

- `uninitialized constant Boxcar::Commands::Boxcar::New (NameError)`
- Rails seems to handle inline namespacing just fine, but it seems to be a problem in Gems. I'm not sure of the root cause at the moment, but this fixes it.

## What Changed?

- Explicitly use `module` where necessary.
