### PR TITLE
Fix rubocop errors

### DIFF
--- a/lib/boxcar/version.rb
+++ b/lib/boxcar/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Boxcar
-  RAILS_VERSION = "~> 5.1.4"
+  RAILS_VERSION = "~> 5.2.1"
   RUBY_VERSION = IO
                  .read("#{File.dirname(__FILE__)}/../../.ruby-version")
                  .strip

--- a/templates/.rubocop.yml
+++ b/templates/.rubocop.yml
@@ -79,9 +79,9 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
-# Reason: Depending on context, sometimes it's better to do
+# Reason: Team preference.
 Style/ClassAndModuleChildren:
-  EnforcedStyle: compact
+  Enabled: false
 
 # Reason: https://blog.bigbinary.com/2012/01/08/alias-vs-alias-method.html
 Style/Alias:

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -11,6 +11,7 @@ gem "rails", "<%= Boxcar::RAILS_VERSION %>"
 
 <%= 'gem "activeadmin"' if config[:activeadmin] %>
 <%= 'gem "active_model_serializers"' if config[:active_model_serializers] %>
+gem "bootsnap", ">= 1.1.0", require: false
 gem "coffee-rails", "~> 4.2"
 <%= 'gem "devise"' if config[:devise] %>
 <%= 'gem "devise_token_auth"' if config[:devise_token_auth] %>

--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -14,7 +14,7 @@ require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires all support files
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.


### PR DESCRIPTION
## Why?
Because of some changes in rubocop and rails, bin/boxcar new generates an app that fails its own linter. 

## What Changed?
- Upgrade rails from 5.1.4 -> 5.2.1.
- Change a linting rule.
- Change a file to pass a linting rule.