### PR TITLE
Remove redundant linting rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,5 @@ RSpec/DescribeClass:
   Enabled: false
 RSpec/BeforeAfterAll:
   Enabled: false
-Style/ClassAndModuleChildren:
-  Enabled: false
 Style/MutableConstant:
   Enabled: false


### PR DESCRIPTION
## Why?

- This rule was changed in the template, which gets included in boxcar's Rubocop, so there's no need for it

## What Changed?

- Remove the rule
