### PR TITLE
Fix readme for .env instructions.

### DIFF
--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -27,7 +27,7 @@ set up this app:
 git clone <REPO_URL>
 cd <APP_DIR>
 bundle install
-cp config/.env.example config/.env
+cp .env.example .env
 bundle exec rails db:setup
 ```
 


### PR DESCRIPTION
## Why?

- Readme was incorrect.

## What Changed?

- Corrected readme. 