### PR TITLE
Properly set Capybara driver in system specs

### DIFF
--- a/templates/boxcar/spec/support/capybara.rb
+++ b/templates/boxcar/spec/support/capybara.rb
@@ -7,5 +7,15 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 # Change this to :chrome to open a local browser
-# driven_by option must also be changed to :chrome in spec_helper.rb
 Capybara.javascript_driver = :headless_chrome
+
+# We need to override the default rspec-rails behavior to use our driver
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by(:headless_chrome)
+  end
+end

--- a/templates/boxcar/spec/support/capybara.rb
+++ b/templates/boxcar/spec/support/capybara.rb
@@ -1,9 +1,11 @@
-Capybara.register_driver :chrome do |app|
+Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new(
     args: %w[--no-sandbox --headless --disable-gpu --disable-dev-shm-usage]
   )
-  Selenium::WebDriver::Chrome.driver_path = `which chromedriver`
+  Selenium::WebDriver::Chrome.driver_path = `which chromedriver`.chomp
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
-Capybara.javascript_driver = :headless_chrome # or optional :chrome for getting a browser locally
+# Change this to :chrome to open a local browser
+# driven_by option must also be changed to :chrome in spec_helper.rb
+Capybara.javascript_driver = :headless_chrome

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -21,14 +21,6 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each, type: :system) do
-    driven_by :rack_test
-  end
-
-  config.before(:each, type: :system, js: true) do
-    driven_by(:headless_chrome)
-  end
-
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -21,6 +21,14 @@ RSpec.configure do |config|
     end
   end
 
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by(:headless_chrome)
+  end
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
## Why?

- In Rails system tests, `rspec-rails` sets the driver to `:selenium` [on this line](https://github.com/rspec/rspec-rails/blob/8c6c9590b94916199950dc8a91a9741d3be30c7c/lib/rspec/rails/example/system_example_group.rb#L90)
- In order to override this, we need a `before(:each)` block that sets the driver via `driven_by`

## What Changed?

- Added new before blocks to `spec_helper` template for `:system` specs
- Fixed a bug when setting the `driver_path` for `chromedriver`
