### PR TITLE
[Documentation] Add comment in render helper for (NoMethodError (undefined method `**') fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - yarn install
   - sudo apt-get update
   - sudo apt-get install chromium-chromedriver
+  - gem install bundler
 install: bundle install
 before_script:
   - export PATH=$PATH:/usr/lib/chromium-browser/
@@ -17,4 +18,3 @@ before_script:
 script:
   - bundle exec rubocop
   - bundle exec rspec
-

--- a/boxcar.gemspec
+++ b/boxcar.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- spec/*`.split("\n")
   s.version = Boxcar::VERSION
 
-  s.add_dependency "bundler", "~> 1.3"
+  s.add_dependency "bundler", "~> 2.0"
   s.add_dependency "rails", Boxcar::RAILS_VERSION
 
   s.add_development_dependency "pry-byebug"

--- a/templates/render_helper.rb
+++ b/templates/render_helper.rb
@@ -8,6 +8,9 @@ module RenderHelper
     }, status: status
   end
 
+  # Note: If you receive this error:
+  #   NoMethodError (undefined method `**' for #<ClassName>)
+  # It means that you need to pass a custom serializer as an argument.
   def render_success_json(data: {}, message: "Success!", serializer: nil)
     render_params = {
       json: data,

--- a/templates/render_helper.rb
+++ b/templates/render_helper.rb
@@ -10,7 +10,7 @@ module RenderHelper
 
   # Note: If you receive this error:
   #   NoMethodError (undefined method `**' for #<ClassName>)
-  # It means that you need to pass a custom serializer as an argument.
+  # It means that you need to create a #<ClassName> serializer.
   def render_success_json(data: {}, message: "Success!", serializer: nil)
     render_params = {
       json: data,


### PR DESCRIPTION
## Why?
When using a custom class you may be met with:

- `NoMethodError (undefined method "**" for #<ClassName>` 

It isn't exactly clear what the solution is for that, so a comment seemed helpful.

## What Changed?

- Adds a small comment to `render_helper.rb` to take the guesswork out for Boxcar users when encountering this error.
